### PR TITLE
add maxBuffer configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,16 @@ os = require('os');
 
 exec = require('child_process').execFile;
 
-parseApk = function(filename, cb) {
+parseApk = function (filename, maxBuffer, cb) {
+  'use strict'
+
+  if (typeof (maxBuffer) == 'function') {
+    maxBuffer = 1024 * 1024;
+    cb = maxBuffer;
+  }
   return exec("" + __dirname + "/../tools/aapt", ['l', '-a', filename], {
-    maxBuffer: 1024 * 1024
-  }, function(err, out) {
+    maxBuffer: maxBuffer
+  }, function (err, out) {
     if (err) {
       return cb(err);
     }
@@ -15,7 +21,7 @@ parseApk = function(filename, cb) {
   });
 };
 
-extractRaw = function(string) {
+extractRaw = function (string) {
   var parts, sep, value;
   sep = '" (Raw: "';
   parts = string.split(sep);
@@ -23,7 +29,7 @@ extractRaw = function(string) {
   return value.substring(1);
 };
 
-parseOutput = function(text, cb) {
+parseOutput = function (text, cb) {
   var depth, element, inManifest, indent, input, line, lines, matches, name, parent, parts, rest, result, stack, type, value, _i, _len;
   if (!text) {
     return cb(new Error('No input!'));


### PR DESCRIPTION
There are some apk files that are larger than the hardcoded maxBuffer size [ 1024*1204 ]  which creates a need to have it as an option .